### PR TITLE
[fix]変数が正しく巻き戻されない不具合を修正

### DIFF
--- a/RewindTimeSystem/RewindTimeSystem.js
+++ b/RewindTimeSystem/RewindTimeSystem.js
@@ -965,7 +965,7 @@ var RewindTimeManager = {
         for (i = 0; i < count; i++) {
             variableParam = variableParamArray[i];
             variableTable = metaSession.getVariableTable(variableParam.col);
-            index = variableTable.getVariableIndexFromId(variableParam.id);
+            index = variableTable.getVariableIndexFromId(variableParam.index);
             variableTable.setVariable(index, variableParam.value);
         }
     },


### PR DESCRIPTION
`createVariableRecord` にて `variableParam.index` となっている箇所が `rewindVariable` では `variableParam.id` となっているため、変数が正しく巻き戻されない不具合を修正するPRです。